### PR TITLE
feat; menu index add string pattern

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -118,7 +118,7 @@ Nav.NavigateTo(
 <nav>
   @foreach (var menuItem in WebPaths.MenuItem)
   {
-    <NavMenuItem MenuItem="menuItem"/>
+    <NavMenuItem @key=@menuItem.Key MenuItem="menuItem"/>
   }
 </nav>
 ```
@@ -128,8 +128,8 @@ Nav.NavigateTo(
 @using BlazorPathHelper
 
 @* メニュー項目を再帰的に表示するコンポーネント *@
-@* key属性にはMenuItem.Indexが利用可能 *@
-<div @key="@MenuItem.Index">
+@* key属性にはMenuItem.Keyが利用可能 *@
+<div>
   <NavLink href="@MenuItem.Path" Match="@NavLinkMatch.All">
     <span class="@MenuItem.Icon" aria-hidden="true"></span>
     @MenuItem.Name
@@ -138,7 +138,7 @@ Nav.NavigateTo(
   @* 子メニュー *@
   @foreach(var childMenuItem in MenuItem.Children)
   {
-    <NavMenuItem MenuItem="childMenuItem"/>
+    <NavMenuItem @key=@childMenuItem.Key MenuItem="childMenuItem"/>
   }
 </div>
 
@@ -224,7 +224,7 @@ public partial class WebPaths
 @* NavMenuItem.razor *@
 @using BlazorPathHelper
 
-<div class="nav-item ps-3 py-1" @key="@MenuItem.Index">
+<div class="nav-item ps-3 py-1">
   <NavLink class="nav-link" href="@MenuItem.Path"
     Match="@(MenuItem.Path != "/" ? NavLinkMatch.Prefix : NavLinkMatch.All)">
     <span class="me-2 fs-5 @MenuItem.Icon" aria-hidden="true"></span>
@@ -233,7 +233,7 @@ public partial class WebPaths
   @foreach(var childMenuItem in MenuItem.Children)
   {
     <nav class="flex-column">
-      <NavMenuItem MenuItem="childMenuItem"/>
+      <NavMenuItem @key=@childMenuItem.Key MenuItem="childMenuItem"/>
     </nav>
   }
 </div>
@@ -282,7 +282,7 @@ public partial class WebPaths
   <FluentNavGroup Href="@MenuItem.Path" Title="@MenuItem.Name" Icon="@((Icon?)MenuItem.Icon)">    
     @foreach(var childMenuItem in MenuItem.Children)
     {
-      <NavMenuItem MenuItem="childMenuItem"/>
+      <NavMenuItem @key=@childMenuItem.Key MenuItem="childMenuItem"/>
     }
   </FluentNavGroup>
 }

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Create `NavMenu.razor` and `NavMenuItem.razor`.
 <nav>
   @foreach (var menuItem in WebPaths.MenuItem)
   {
-    <NavMenuItem MenuItem="menuItem"/>
+    <NavMenuItem @key=@menuItem.Key MenuItem="menuItem"/>
   }
 </nav>
 ```
@@ -130,7 +130,7 @@ Create `NavMenu.razor` and `NavMenuItem.razor`.
 
 @* A component that recursively displays menu items *@
 @* The key attribute can use MenuItem.Index *@
-<div @key="@MenuItem.Index">
+<div>
   <NavLink href="@MenuItem.Path" Match="@NavLinkMatch.All">
     <span class="@MenuItem.Icon" aria-hidden="true"></span>
     @MenuItem.Name
@@ -139,7 +139,7 @@ Create `NavMenu.razor` and `NavMenuItem.razor`.
   @* Submenus *@
   @foreach(var childMenuItem in MenuItem.Children)
   {
-    <NavMenuItem MenuItem="childMenuItem"/>
+    <NavMenuItem @key=@childMenuItem.Key MenuItem="childMenuItem"/>
   }
 </div>
 
@@ -224,7 +224,7 @@ public partial class WebPaths
 @* NavMenuItem.razor *@
 @using BlazorPathHelper
 
-<div class="nav-item ps-3 py-1" @key="@MenuItem.Index">
+<div class="nav-item ps-3 py-1">
   <NavLink class="nav-link" href="@MenuItem.Path"
     Match="@(MenuItem.Path != "/" ? NavLinkMatch.Prefix : NavLinkMatch.All)">
     <span class="me-2 fs-5 @MenuItem.Icon" aria-hidden="true"></span>
@@ -233,7 +233,7 @@ public partial class WebPaths
   @foreach(var childMenuItem in MenuItem.Children)
   {
     <nav class="flex-column">
-      <NavMenuItem MenuItem="childMenuItem"/>
+      <NavMenuItem @key=@childMenuItem.Key MenuItem="childMenuItem"/>
     </nav>
   }
 </div>
@@ -282,7 +282,7 @@ Then, use it as follows.
   <FluentNavGroup Href="@MenuItem.Path" Title="@MenuItem.Name" Icon="@((Icon?)MenuItem.Icon)">    
     @foreach(var childMenuItem in MenuItem.Children)
     {
-      <NavMenuItem MenuItem="childMenuItem"/>
+      <NavMenuItem @key=@childMenuItem.Key MenuItem="childMenuItem"/>
     }
   </FluentNavGroup>
 }

--- a/examples/Example.FluentUI/Layout/NavMenu.razor
+++ b/examples/Example.FluentUI/Layout/NavMenu.razor
@@ -8,7 +8,7 @@
         <FluentNavMenu Id="main-menu" Width="250" Collapsible="true" Title="Navigation menu" @bind-Expanded="expanded" CustomToggle="true">
             @foreach(var menuItem in WebPaths.MenuItem)
             {
-                <NavMenuItem MenuItem="menuItem"/>
+                <NavMenuItem @key=@menuItem.Key MenuItem="menuItem"/>
             }
         </FluentNavMenu>
     </nav>

--- a/examples/Example.FluentUI/Layout/NavMenuItem.razor
+++ b/examples/Example.FluentUI/Layout/NavMenuItem.razor
@@ -2,7 +2,7 @@
 
 @if(MenuItem.Children.Length > 0)
 {
-    <FluentNavGroup @key=@MenuItem.Index Href="@MenuItem.Path" Title="@MenuItem.Name" Icon="@((Icon?)MenuItem.Icon)">    
+    <FluentNavGroup @key=@MenuItem.Key Href="@MenuItem.Path" Title="@MenuItem.Name" Icon="@((Icon?)MenuItem.Icon)">    
         @foreach(var childMenuItem in MenuItem.Children)
         {
             <NavMenuItem MenuItem="childMenuItem"/>
@@ -11,7 +11,7 @@
 }
 else
 {
-    <FluentNavLink @key=@MenuItem.Index Href="@MenuItem.Path" Match="@(MenuItem.Path != "/" ? NavLinkMatch.Prefix : NavLinkMatch.All)"
+    <FluentNavLink @key=@MenuItem.Key Href="@MenuItem.Path" Match="@(MenuItem.Path != "/" ? NavLinkMatch.Prefix : NavLinkMatch.All)"
                    Icon="@((Icon?)MenuItem.Icon)" IconColor="Color.Accent">
         @MenuItem.Name
     </FluentNavLink>

--- a/examples/Example.Plain/Layout/NavMenu.razor
+++ b/examples/Example.Plain/Layout/NavMenu.razor
@@ -11,7 +11,7 @@
     <nav class="flex-column pe-3">
         @foreach(var menuItem in WebPaths.MenuItem)
         {
-            <NavMenuItem MenuItem="menuItem"/>
+            <NavMenuItem @key=menuItem.Key MenuItem="menuItem"/>
         }
     </nav>
 </div>

--- a/examples/Example.Plain/Layout/NavMenuItem.razor
+++ b/examples/Example.Plain/Layout/NavMenuItem.razor
@@ -1,6 +1,6 @@
 ﻿@using BlazorPathHelper
 
-<div class="nav-item ps-3 py-1" @key="@MenuItem.Index">
+<div class="nav-item ps-3 py-1">
     <NavLink class="nav-link" href="@MenuItem.Path"
              Match="@(MenuItem.Path != "/" ? NavLinkMatch.Prefix : NavLinkMatch.All)">
         <span class="me-2 fs-5 @MenuItem.Icon" aria-hidden="true"></span>
@@ -10,7 +10,7 @@
     @foreach(var childMenuItem in MenuItem.Children)
     {
         <nav class="flex-column">
-            <NavMenuItem MenuItem="childMenuItem"/>
+            <NavMenuItem @key=childMenuItem.Key MenuItem="childMenuItem" />
         </nav>
     }
 </div>

--- a/src/BlazorPathHelper.Core/BlazorPathMenuItem.cs
+++ b/src/BlazorPathHelper.Core/BlazorPathMenuItem.cs
@@ -6,7 +6,12 @@
 public record BlazorPathMenuItem
 {
     /// <summary>
-    /// Index in the entire path definition. It is mainly intended to be used for the @key attribute.
+    /// Key of the item. It is mainly intended to be used for the @key attribute.
+    /// </summary>
+    public string Key => Index.ToString();
+
+    /// <summary>
+    /// Index in the entire path definition.
     /// </summary>
     public int Index { get; init; }
 


### PR DESCRIPTION
This pull request includes changes to update the key attributes in navigation components to use `MenuItem.Key` instead of `MenuItem.Index`. This change impacts multiple files and components across the project.

Changes in core library:

* [`src/BlazorPathHelper.Core/BlazorPathMenuItem.cs`](diffhunk://#diff-22cffa85f218d261c031398c918c421416018b6127ac54234a0246e85b220a31L9-R14): Added `Key` property to `BlazorPathMenuItem` to return `Index.ToString()`, and updated the summary to reflect its intended use for the `@key` attribute.