### PR TITLE
fix: Incorrect output of Namespace is Ambiguous error for certain directory structures

### DIFF
--- a/src/BlazorPathHelper.Generator/CodeBuilders/ParseRecordToRazorCls.cs
+++ b/src/BlazorPathHelper.Generator/CodeBuilders/ParseRecordToRazorCls.cs
@@ -30,8 +30,10 @@ internal class ParseRecordToRazorCls(ParseRecord record, ImmutableArray<ParseRaz
         {
             // => so namespace is not found in the source code
             // search for the namespace from the Razor side
-            // first. search by FullClassName
-            var searchRazorInfo = structures.Where(s => s.FullClassName == PageFullClassName).ToList();
+            // first. search by FullClassName or PartialClassName
+            var searchRazorInfo = structures
+                .Where(s => s.FullClassName == PageFullClassName || s.PartialClassName == PageFullClassName)
+                .ToList();
             if (searchRazorInfo.Count == 0)
             {
                 // second. search by PageClassName

--- a/src/BlazorPathHelper.Generator/Models/ParseRazorStructure.cs
+++ b/src/BlazorPathHelper.Generator/Models/ParseRazorStructure.cs
@@ -37,4 +37,15 @@ internal record ParseRazorStructure
     /// full class name
     /// </summary>
     public string FullClassName => $"{Namespace}.{PageClassName}";
+
+    /// <summary>
+    /// full class name without default namespace.
+    /// </summary>
+    /// <remarks>
+    /// e.g.
+    /// * default namespace: "Example.FluentUI"
+    /// * full class name: "Example.FluentUI.Foo.Bar.Test"
+    /// => "Foo.Bar.Test"
+    /// </remarks>
+    public string PartialClassName => FullClassName.Replace(DefaultNamespace,"").Trim('.');
 }

--- a/tests/BlazorPathHelper.Tests/RazorClassTestAmbigous.cs
+++ b/tests/BlazorPathHelper.Tests/RazorClassTestAmbigous.cs
@@ -1,0 +1,42 @@
+﻿using System.Linq;
+using FluentAssertions;
+using Xunit;
+
+// check test for issue #20
+namespace BlazorPathHelper.Tests
+{
+    [BlazorPath]
+    public partial class AmbiguousWebPaths
+    {
+        [Page<Foo.Sample>]
+        public const string Sample = "/sample";
+    }
+
+    public class RazorClassTestAmbiguous
+    {
+        [Fact]
+        public void TestSample()
+        {
+            // check route attribute (Foo.Sample)
+            var attribute = typeof(Foo.Sample).GetCustomAttributesData()
+                .First(attr => attr.AttributeType.Name == "RouteAttribute");
+            attribute.ConstructorArguments[0].Value.Should().Be(AmbiguousWebPaths.Sample);
+            // check route attribute (Foo.Bar.Sample)
+            // should not be found
+            var attribute2 = typeof(Foo.Bar.Sample).GetCustomAttributesData()
+                .FirstOrDefault(attr => attr.AttributeType.Name == "RouteAttribute");
+            attribute2.Should().BeNull();
+        }
+    }
+
+}
+
+// for test
+namespace BlazorPathHelper.Tests.Foo
+{
+    public partial class Sample;
+}
+namespace BlazorPathHelper.Tests.Foo.Bar
+{
+    public partial class Sample;
+}


### PR DESCRIPTION
The namespace guesser has been improved to take into account standard namespaces.
And corresponding test has also been added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added `PartialClassName` property to improve class name handling
	- Enhanced search flexibility for Razor structures by supporting partial class name matching

- **Tests**
	- Added new test class `RazorClassTestAmbiguous` to validate routing attribute behavior
	- Implemented test method to check routing attribute scenarios

- **Documentation**
	- Added XML documentation for new `PartialClassName` property

<!-- end of auto-generated comment: release notes by coderabbit.ai -->