### PR TITLE
Add QueryNameAttribute for custom query names and update documentation

### DIFF
--- a/.github/workflows/gpt-translate-commit.yaml
+++ b/.github/workflows/gpt-translate-commit.yaml
@@ -1,12 +1,15 @@
 # https://g-t.vercel.app/docs/examples/commit
 name: GPT Translate per Commit from Japanese
- 
+
+# comment out because of the bug in gpt-translate when translating multiple languages
 on:
   push:
-    paths:
-      - 'docs/ja/**.md'
+    # paths:
+    #   - 'docs/ja/**.md'
+    # branches-ignore:
+    #   - release/**
     branches-ignore:
-      - release/**
+      - '**'
   
 jobs:
   gpt_translate:

--- a/docs/en/Features/UrlBuilder/QuerySupport.md
+++ b/docs/en/Features/UrlBuilder/QuerySupport.md
@@ -75,12 +75,12 @@ As you can see from the generated code above, each property of the `QueryRecord`
 
 ## Changing Query Names
 
-When you specify the `#!csharp [Query<QueryRecord>]` attribute, the query name uses the property name of `QueryRecord` as is. If you want to change the query name, add the `#!csharp [SupplyParameterFromQuery(Name = "shortName")]` attribute. (This is the same as the traditional method of specifying.)
+When you specify the `#!csharp [Query<QueryRecord>]` attribute, the query name uses the property name of `QueryRecord` as is. If you want to change the query name, add the `#!csharp [QueryName("shortName")]` attribute.
 
 ```csharp title="WebPaths.cs"
 public record QueryRecord
 {
-    [SupplyParameterFromQuery(Name = "short")]
+    [QueryName("short")] // or [SupplyParameterFromQuery(Name = "short")]
     public required string SuperLongName { get; set; }
 }
 

--- a/docs/ja/Features/UrlBuilder/QuerySupport.md
+++ b/docs/ja/Features/UrlBuilder/QuerySupport.md
@@ -78,13 +78,13 @@ public static string CounterWithQuery(QueryRecord __query)
 ## クエリ名を変更する
 
 `#!csharp [Query<QueryRecord>]`属性を指定した場合、クエリ名は`QueryRecord`のプロパティ名がそのまま使用されます。
-クエリ名を変更したい場合は、`#!csharp [SupplyParameterFromQuery(Name = "shortName")]`属性を付与してください。(従来の指定方法と同じです)
+クエリ名を変更したい場合は、`#!csharp [QueryName("shortName")]`属性を付与してください。
 
 
 ```csharp title="WebPaths.cs"
 public record QueryRecord
 {
-    [SupplyParameterFromQuery(Name = "short")]
+    [QueryName("short")] // or [SupplyParameterFromQuery(Name = "short")]
     public required string SuperLongName { get; set; }
 }
 

--- a/docs/zh/Features/UrlBuilder/QuerySupport.md
+++ b/docs/zh/Features/UrlBuilder/QuerySupport.md
@@ -79,12 +79,12 @@ public static string CounterWithQuery(QueryRecord __query)
 ### 更改查询名称
 
 指定 `#!csharp [Query<QueryRecord>]` 属性时，查询名称直接使用 `QueryRecord` 的属性名。
-如果想更改查询名称，请添加 `#!csharp [SupplyParameterFromQuery(Name = "shortName")]` 属性。（与传统指定方法相同）
+如果想更改查询名称，请添加 `#!csharp [QueryName("shortName")]` 属性。
 
 ```csharp title="WebPaths.cs"
 public record QueryRecord
 {
-    [SupplyParameterFromQuery(Name = "short")]
+    [QueryName("short")] // or [SupplyParameterFromQuery(Name = "short")]
     public required string SuperLongName { get; set; }
 }
 

--- a/src/BlazorPathHelper.Core/QueryAttribute.cs
+++ b/src/BlazorPathHelper.Core/QueryAttribute.cs
@@ -8,3 +8,9 @@ namespace BlazorPathHelper;
 /// <typeparam name="TQuery">Query Type</typeparam>
 [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property, Inherited = false, AllowMultiple = false)]
 public class QueryAttribute<TQuery> : Attribute;
+
+/// <summary>
+/// Attribute to specify the display name of the query value
+/// </summary>
+/// <param name="name">name of the query value</param>
+public class QueryNameAttribute(string name) : Attribute;

--- a/tests/BlazorPathHelper.Tests/QueryTest.cs
+++ b/tests/BlazorPathHelper.Tests/QueryTest.cs
@@ -17,6 +17,8 @@ public record Query4
 {
     [SupplyParameterFromQuery(Name = "short")]
     public required string CustomTest { get; set; }
+    [QueryName("short2")]
+    public required string CustomTest2 { get; set; }
 }
 // field pattern
 public record Query5
@@ -80,8 +82,9 @@ public class QueryTest
     [Fact]
     public void QueryTest4()
     {
-        DefinitionForQuery.Helper.QueryTest4(new() { CustomTest = "hello" })
-            .Should().Be("/query-test/4?short=hello");
+        Query4 q4 = new() { CustomTest = "hello", CustomTest2 = "world" };
+        DefinitionForQuery.Helper.QueryTest4(q4)
+            .Should().Be("/query-test/4?short=hello&short2=world");
     }
 
     [Fact]


### PR DESCRIPTION
Introduce the `QueryNameAttribute` to allow custom display names for queries and update the query extraction logic accordingly. Documentation in English, Japanese, and Chinese reflects these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated documentation for URL builder's query support across multiple languages (English, Japanese, Chinese)
	- Replaced `SupplyParameterFromQuery` attribute with new `QueryName` attribute for specifying custom query names

- **New Features**
	- Introduced `QueryNameAttribute` to enhance query parameter naming flexibility
	- Added ability to specify custom query parameter names more intuitively

- **Refactor**
	- Improved attribute handling for query parameter naming
	- Centralized logic for extracting URL names from attributes

- **Tests**
	- Added new test case to verify multiple query parameter handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->