### PR TITLE
Drop pre-release and adjust styles and documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: "[Bug]"
+title: "bug: "
 labels: bug
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: "[Feat]"
+title: "feat: "
 labels: enhancement
 assignees: ''
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,14 +2,6 @@
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
-      - release/**
-    paths:
-      - '**.csproj'
-      - '**.cs'
-      - '**.yaml'
         
 jobs:
   release:

--- a/docs/assets/css/custom.css
+++ b/docs/assets/css/custom.css
@@ -9,7 +9,7 @@
 }
 
 html {
-	font-size: 17.5pt;
+	font-size: 15pt;
 }
 
 .md-nav__link {

--- a/docs/en/Features/UrlBuilder/index.md
+++ b/docs/en/Features/UrlBuilder/index.md
@@ -31,6 +31,33 @@ public partial class WebPaths
     }
     ```
 
+## Supporting `PathBase` Specification
+
+When deploying under a subdirectory, you can configure the generated URLs to consider the `PathBase` by setting it as follows:
+
+```csharp title="WebPaths.cs"
+[BlazorPath(PathBaseValue = PathBase)]
+public partial class WebPaths
+{
+  [Item(Ignore = true)]
+  private const string PathBase = "/subdir";
+  // ...
+}
+```
+
+The value specified here is directly passed to both [`<base href>`](https://github.com/arika0093/BlazorPathHelper/blob/main/examples/Example.ServerPathBase/Components/App.razor#L7) and [`app.UsePathBase()`](https://github.com/arika0093/BlazorPathHelper/blob/main/examples/Example.ServerPathBase/Program.cs#L13).
+
+```razor title="App.razor"
+<base href="@WebPaths.PathBase" />
+```
+
+```csharp title="Program.cs"
+app.UsePathBase(WebPaths.PathBase);
+```
+
+For more details, refer to [Example.ServerPathBase](https://github.com/arika0093/BlazorPathHelper/tree/main/examples/Example.ServerPathBase).
+
+
 ## URL Definition Examples
 
 All URL definitions listed in the [official documentation](https://learn.microsoft.com/en-us/aspnet/core/blazor/fundamentals/routing?view=aspnetcore-9.0#route-constraints) are supported. You can also refer to the [test cases](https://github.com/arika0093/BlazorPathHelper/blob/main/tests/BlazorPathHelper.Tests/PathTestWithArgs.cs) for this program.

--- a/docs/ja/Features/UrlBuilder/index.md
+++ b/docs/ja/Features/UrlBuilder/index.md
@@ -30,6 +30,31 @@ public partial class WebPaths
     }
     ```
 
+## `PathBase`の指定に対応する
+サブディレクトリ以下に展開を行う場合、生成されるURLがPathBaseを考慮できるよう以下のように設定します。
+
+```csharp title="WebPaths.cs"
+[BlazorPath(PathBaseValue = PathBase)]
+public partial class WebPaths
+{
+    [Item(Ignore = true)]
+    private const string PathBase = "/subdir";
+    // ...
+}
+```
+
+ここで指定した値をそのまま[`<base href>`](https://github.com/arika0093/BlazorPathHelper/blob/main/examples/Example.ServerPathBase/Components/App.razor#L7)および[`app.UsePathBase()`](https://github.com/arika0093/BlazorPathHelper/blob/main/examples/Example.ServerPathBase/Program.cs#L13)に渡します。
+
+```razor title="App.razor"
+<base href="@WebPaths.PathBase" />
+```
+
+```csharp title="Program.cs"
+app.UsePathBase(WebPaths.PathBase);
+```
+
+詳細は[Example.ServerPathBase](https://github.com/arika0093/BlazorPathHelper/tree/main/examples/Example.ServerPathBase)を参照してください。
+
 ## URL定義の凡例
 [公式ドキュメント](https://learn.microsoft.com/ja-jp/aspnet/core/blazor/fundamentals/routing?view=aspnetcore-9.0#route-constraints)に記載されているURL定義は全て対応しています。
 このプログラムの[テストケース](https://github.com/arika0093/BlazorPathHelper/blob/main/tests/BlazorPathHelper.Tests/PathTestWithArgs.cs)も参照してください。

--- a/docs/zh/Features/UrlBuilder/index.md
+++ b/docs/zh/Features/UrlBuilder/index.md
@@ -29,6 +29,33 @@ public partial class WebPaths
     }
     ```
 
+## 支持指定 `PathBase`
+
+如果需要在子目录下展开应用，可以通过以下设置使生成的 URL 考虑到 PathBase：
+
+```csharp title="WebPaths.cs"
+[BlazorPath(PathBaseValue = PathBase)]
+public partial class WebPaths
+{
+  [Item(Ignore = true)]
+  private const string PathBase = "/subdir";
+  // ...
+}
+```
+
+这里指定的值会直接传递给 [`<base href>`](https://github.com/arika0093/BlazorPathHelper/blob/main/examples/Example.ServerPathBase/Components/App.razor#L7) 和 [`app.UsePathBase()`](https://github.com/arika0093/BlazorPathHelper/blob/main/examples/Example.ServerPathBase/Program.cs#L13)。
+
+```razor title="App.razor"
+<base href="@WebPaths.PathBase" />
+```
+
+```csharp title="Program.cs"
+app.UsePathBase(WebPaths.PathBase);
+```
+
+详情请参阅 [Example.ServerPathBase](https://github.com/arika0093/BlazorPathHelper/tree/main/examples/Example.ServerPathBase)。
+
+
 ## URL定义示例
 [官方文档](https://learn.microsoft.com/ja-jp/aspnet/core/blazor/fundamentals/routing?view=aspnetcore-9.0#route-constraints)中列出的所有URL定义都支持。请参阅该程序的[测试用例](https://github.com/arika0093/BlazorPathHelper/blob/main/tests/BlazorPathHelper.Tests/PathTestWithArgs.cs)。
 


### PR DESCRIPTION
Remove automatic pre-release, adjust HTML font size for better readability, and update issue template titles for consistency. Enhance documentation to support `PathBase` specification in `UrlBuilder`.