### PR TITLE
Add BlazorPathHelper.Migration tool and update documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 bin/
 obj/
 /packages/
+sandbox/
 riderModule.iml
 /_ReSharper.Caches/
 .idea/

--- a/BlazorPathHelper.sln
+++ b/BlazorPathHelper.sln
@@ -26,10 +26,18 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Example.ServerPathBase", "examples\Example.ServerPathBase\Example.ServerPathBase.csproj", "{1E02AE67-8B38-4F72-91AF-F9D22CFE5961}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{DDB4EF12-CC4E-5E88-E6FC-71A802F4DE97}"
+	ProjectSection(SolutionItems) = preProject
+		src\Directory.Build.props = src\Directory.Build.props
+	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "examples", "examples", "{4C0B733E-530E-4249-86A9-5846734837B6}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{C7E9EAEA-09DC-44FE-B860-41708679EAEA}"
+	ProjectSection(SolutionItems) = preProject
+		tests\Directory.Build.props = tests\Directory.Build.props
+	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlazorPathHelper.Migration", "src\BlazorPathHelper.Migration\BlazorPathHelper.Migration.csproj", "{35E0994A-A511-40EC-A3A5-1A46090AAF8C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -81,6 +89,10 @@ Global
 		{1E02AE67-8B38-4F72-91AF-F9D22CFE5961}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1E02AE67-8B38-4F72-91AF-F9D22CFE5961}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1E02AE67-8B38-4F72-91AF-F9D22CFE5961}.Release|Any CPU.Build.0 = Release|Any CPU
+		{35E0994A-A511-40EC-A3A5-1A46090AAF8C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{35E0994A-A511-40EC-A3A5-1A46090AAF8C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{35E0994A-A511-40EC-A3A5-1A46090AAF8C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{35E0994A-A511-40EC-A3A5-1A46090AAF8C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -97,6 +109,7 @@ Global
 		{711B0C92-16E7-4C47-8AF7-1C89060D2C3C} = {4C0B733E-530E-4249-86A9-5846734837B6}
 		{EACA2125-D882-4931-B343-CFF229422853} = {4C0B733E-530E-4249-86A9-5846734837B6}
 		{1E02AE67-8B38-4F72-91AF-F9D22CFE5961} = {4C0B733E-530E-4249-86A9-5846734837B6}
+		{35E0994A-A511-40EC-A3A5-1A46090AAF8C} = {DDB4EF12-CC4E-5E88-E6FC-71A802F4DE97}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {36AE79DD-7720-450D-B7DC-4E65CA5F39F2}

--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ Install [BlazorPathHelper](https://www.nuget.org/packages/BlazorPathHelper/) in 
 ```bash
 dotnet add package BlazorPathHelper
 ```
+
+Alternatively, automatic setup can also be performed. For more details, refer to [this guide](https://arika0093.github.io/BlazorPathHelper/latest/GettingStarted).
+
+```bash
+dotnet tool install --global BlazorPathHelper.Migration --prerelease
+dotnet bph-migration
+```
+
 ### Minimum URL Builder
 Create a `WebPaths.cs` file.
 

--- a/docs/en/GettingStarted/index.md
+++ b/docs/en/GettingStarted/index.md
@@ -281,3 +281,29 @@ For details, refer to the samples for each framework.
 
 ### Customization
 You can customize the menu generation with descriptions, icons, localization, and more. For details, refer to [Menu Structure Customization](../Features/MenuBuilder/MenuCustomization.md).
+
+## Automatic Installation (Beta)
+You can easily install BlazorPathHelper into a specified project by running the following commands:
+
+```bash
+dotnet tool install --global BlazorPathHelper.Migration --prerelease
+# Or
+# dotnet new tool-manifest
+# dotnet tool install BlazorPathHelper.Migration --prerelease
+dotnet bph-migration
+```
+
+This tool performs the following tasks:
+
+* Searches for `*.csproj` files under the execution directory and displays options for selection.
+* Installs the latest version of `BlazorPathHelper` into the selected project.
+* Searches for `.razor` files under the project directory, reads the values of `@page` attributes, and generates a `WebPaths.cs` file.
+  * Currently, only `.razor` files are targeted.
+* (Optional) Replaces the values of `@page` attributes with the generated `const string` variables.
+  * This makes URL management easier.
+
+!!! warning "Caution!"
+
+    This tool references and modifies existing code.
+    Be sure to create a backup using git or another version control system before running it.
+    (The tool will also display a warning if there are uncommitted changes in git.)

--- a/docs/ja/GettingStarted/index.md
+++ b/docs/ja/GettingStarted/index.md
@@ -294,4 +294,28 @@ public partial class WebPaths
 メニューの生成に際して、説明文・アイコン・ローカライズなどのカスタマイズが可能です。
 詳細は[メニュー構造のカスタマイズ](../Features/MenuBuilder/MenuCustomization.md)を参照してください。
 
+## 自動導入 (ベータ版)
+以下のコマンドを実行することで、BlazorPathHelperを指定したプロジェクトに簡易導入できます。
 
+```bash
+dotnet tool install --global BlazorPathHelper.Migration --prerelease
+# または
+# dotnet new tool-manifest
+# dotnet tool install BlazorPathHelper.Migration --prerelease
+dotnet bph-migration
+```
+
+このツールは以下のことを行います。
+
+* 実行ディレクトリの下に存在する `*.csproj`ファイルを検索し、選択肢を表示します。
+* 選択したプロジェクトに、最新版の`BlazorPathHelper`をインストールします。
+* プロジェクト配下の`.razor`ファイルを検索し、`@page`属性の値を読み取り`WebPaths.cs`ファイルを生成します。
+  * 現在`.razor`ファイルのみを対象としています。
+* (オプション) `@page`属性の値を生成した`const string`の変数に置き換えます。
+  * これによりURLの管理が容易になります。
+
+!!! warning "注意！"
+
+    このツールは既存のコードを参照し、一部書き換えます。
+    使用する場合は、必ずgit等でバックアップを生成してから実行してください。
+    (ツール上でもgitの変更が存在する場合警告を表示します)

--- a/docs/zh/GettingStarted/index.md
+++ b/docs/zh/GettingStarted/index.md
@@ -290,3 +290,29 @@ public partial class WebPaths
 ### 自定义
 在生成菜单时，可以进行描述、图标、本地化等自定义。
 详细信息请参阅[菜单结构的自定义](../Features/MenuBuilder/MenuCustomization.md)。
+
+## 自动导入 (测试版)
+通过执行以下命令，可以将BlazorPathHelper轻松导入到指定的项目中。
+
+```bash
+dotnet tool install --global BlazorPathHelper.Migration --prerelease
+# 或者
+# dotnet new tool-manifest
+# dotnet tool install BlazorPathHelper.Migration --prerelease
+dotnet bph-migration
+```
+
+此工具将执行以下操作：
+
+* 搜索当前目录下的`*.csproj`文件，并显示选择列表。
+* 将最新版的`BlazorPathHelper`安装到选定的项目中。
+* 搜索项目下的`.razor`文件，读取`@page`属性的值，并生成`WebPaths.cs`文件。
+  * 当前仅支持`.razor`文件。
+* （可选）将`@page`属性的值替换为生成的`const string`变量。
+  * 这样可以更方便地管理URL。
+
+!!! warning "注意！"
+
+    此工具会参考并部分修改现有代码。
+    使用前，请务必通过git等工具备份代码。
+    （工具在检测到git有未提交的更改时也会显示警告）

--- a/nuget.config
+++ b/nuget.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
     <!--To inherit the global NuGet package sources remove the <clear/> line below -->

--- a/src/BlazorPathHelper.Generator/BlazorPathSourceGenerator.cs
+++ b/src/BlazorPathHelper.Generator/BlazorPathSourceGenerator.cs
@@ -146,6 +146,7 @@ public class BlazorPathHelperSourceGenerator : IIncrementalGenerator
     /// Iterates over parse records with a non-null page type and constructs a partial class definition with a route derived from the record's path (excluding the path base).
     /// The generated class includes namespace, parameter, and query code segments assembled from the provided Razor structures. If a namespace ambiguity is detected during generation, a diagnostic error is reported.
     /// </remarks>
+    /// <param name="context">The source production context used to add the generated Razor class source.</param>
     /// <param name="records">List of parsed records containing Razor page attribute data; only records with a valid page type are processed.</param>
     /// <param name="structures">Immutable array of parsed Razor structures providing additional context needed for code generation.</param>
     private static void ExportRazorClassCode(

--- a/src/BlazorPathHelper.Migration/BlazorPathHelper.Migration.csproj
+++ b/src/BlazorPathHelper.Migration/BlazorPathHelper.Migration.csproj
@@ -1,0 +1,29 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <InvariantGlobalization>true</InvariantGlobalization>
+	<PackAsTool>true</PackAsTool>
+	<ToolCommandName>bph-migration</ToolCommandName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="ConsoleAppFramework" Version="5.*">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.*" />
+    <PackageReference Include="Sharprompt" Version="2.*" />
+    <PackageReference Include="ZLogger" Version="2.*" />
+  </ItemGroup>
+
+</Project>

--- a/src/BlazorPathHelper.Migration/Builder/WebPathsFileExporter.cs
+++ b/src/BlazorPathHelper.Migration/Builder/WebPathsFileExporter.cs
@@ -1,0 +1,170 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using BlazorPathHelper.Migration.Helpers;
+using BlazorPathHelper.Migration.Models;
+using Microsoft.Extensions.Logging;
+using Sharprompt;
+using System.Text;
+using System.Text.RegularExpressions;
+using ZLogger;
+
+namespace BlazorPathHelper.Migration.Builder;
+
+/// <summary>
+/// This class is responsible for exporting the generated web paths to a file.
+/// </summary>
+internal class WebPathsFileExporter(
+    ILogger<WebPathsFileExporter> logger
+)
+{
+    /// <summary>
+    /// Extends the content of the generated file with additional web paths.
+    /// </summary>
+    public string ExtendFileContent(
+        IEnumerable<WebPathItemStructure> webPaths,
+        CommandLineParsedArguments args)
+    {
+        var content = "";
+        var outputFile = args.OutputFileFullPath;
+        if (Path.Exists(outputFile))
+        {
+            content = File.ReadAllText(outputFile);
+        } else {
+            content = PlainWebPathFileContent(args);
+        }
+        var syntaxTree = CSharpSyntaxTree.ParseText(content);
+        var root = syntaxTree.GetRoot();
+
+        // Find the class declaration in the syntax tree
+        var classDeclaration = root.DescendantNodes()
+            .OfType<ClassDeclarationSyntax>()
+            .FirstOrDefault();
+        if (classDeclaration == null) {
+            throw new InvalidOperationException("No class declaration found in the file.");
+        }
+
+        // Create a new field declaration for each web path
+        var updatedClass = classDeclaration;
+        foreach (var webpath in webPaths)
+        {
+            // if exist variable name, skip
+            var variableName = webpath.NoConflictVariableName(webPaths);
+            var existingField = classDeclaration.Members
+                .OfType<FieldDeclarationSyntax>()
+                .FirstOrDefault(f => f.Declaration.Variables
+                    .Any(v => v.Identifier.Text == variableName));
+            if (existingField != null)
+            {
+                logger.ZLogTrace($"Field {variableName} already exists. Skipping.");
+                continue;
+            }
+            // Create a new field declaration
+            // e.g. public const string Sample = "/sample";
+            var newField = SyntaxFactory.FieldDeclaration(
+                SyntaxFactory.VariableDeclaration(
+                    SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.StringKeyword)))
+                .WithVariables(SyntaxFactory.SingletonSeparatedList(
+                    SyntaxFactory.VariableDeclarator(variableName)
+                        .WithInitializer(SyntaxFactory.EqualsValueClause(
+                            SyntaxFactory.LiteralExpression(SyntaxKind.StringLiteralExpression,
+                                SyntaxFactory.Literal(webpath.Path)))))))
+                .WithModifiers(SyntaxFactory.TokenList(
+                    SyntaxFactory.Token(webpath.Accessibility),
+                    SyntaxFactory.Token(SyntaxKind.ConstKeyword)));
+            // add
+            updatedClass = updatedClass.AddMembers(newField);
+        }
+        // to string
+        var updatedRoot = root.ReplaceNode(classDeclaration, updatedClass);
+        var formattedCode = updatedRoot.NormalizeWhitespace().ToFullString();
+        return formattedCode;
+    }
+
+    /// <summary>
+    /// Generates the content of the web paths file in plain format.
+    /// </summary>
+    private string PlainWebPathFileContent(
+        CommandLineParsedArguments args)
+    {
+        return $$"""
+        #pragma warning disable CA1050
+
+        using BlazorPathHelper;
+
+        [BlazorPath]
+        public partial class {{args.OutputClassName}}
+        {
+        }
+        """;
+    }
+
+    /// <summary>
+    /// Exports the generated file to the specified path.
+    /// </summary>
+    public void ExportGeneratedWebPathsFile(
+        string contents,
+        CommandLineParsedArguments args)
+    {
+        var outputPath = args.OutputFileFullPath;
+        var outputFileName = Path.GetFileName(outputPath);
+        if (File.Exists(outputPath) && !args.ForceExport)
+        {
+            var isOverwrite = Prompt.Confirm(
+                $"File {outputFileName} already exists. Do you want to overwrite it?",
+                false);
+            if (!isOverwrite)
+            {
+                logger.LogInformation($"File {outputFileName} already exists. Skipping export.");
+                return;
+            }
+        }
+        if(args.IsDryRun)
+        {
+            logger.ZLogDebug($"Dry run: Exporting to {outputFileName}.");
+            return;
+        }
+        File.WriteAllText(outputPath, contents);
+        logger.LogInformation($"Exported to {outputFileName} successfully.");
+    }
+
+    /// <summary>
+    /// Replaces the @page attribute in Razor files with a variable name.
+    /// </summary>
+    public void ReplaceRazorPageAttributeToVariable(
+        IEnumerable<WebPathItemStructure> webPaths,
+        CommandLineParsedArguments args
+    )
+    {
+        if(!args.IsReplacePageAttributeString)
+        {
+            logger.ZLogInformation($"Skipping @page attribute replacement.");
+            return;
+        }
+        foreach (var webPath in webPaths)
+        {
+            var filePath = webPath.Source.FilePath;
+            var fileName = Path.GetFileName(filePath);
+            var fileContent = webPath.Source.FileContent;
+            var variableName = webPath.NoConflictVariableName(webPaths);
+            var exportClass = args.OutputClassName;
+            // replace @page\s+"{webPath.Path}" -> @attribute [Route({exportClass}.{variableName})]
+            // use regex to replace
+            var regex = new Regex($@"@page\s+""{webPath.Path}""", RegexOptions.IgnoreCase);
+            var beforeAttr = $"@page \"{webPath.Path}\"";
+            var afterAttr = $"@attribute [Route({exportClass}.{variableName})]";
+            var newContent = regex.Replace(fileContent, afterAttr);
+            // export to file
+            if (args.IsDryRun)
+            {
+                logger.ZLogDebug($"Dry run: '{beforeAttr}' -> '{afterAttr}'");
+                return;
+            }
+            else
+            {
+                File.WriteAllText(filePath, newContent);
+                logger.ZLogInformation($"Replaced @page attribute in {fileName}.");
+            }
+        }
+    }
+}

--- a/src/BlazorPathHelper.Migration/Factory/SourceFileDataFactory.cs
+++ b/src/BlazorPathHelper.Migration/Factory/SourceFileDataFactory.cs
@@ -1,0 +1,30 @@
+﻿using BlazorPathHelper.Migration.Models;
+
+namespace BlazorPathHelper.Migration.Factory;
+
+internal class SourceFileDataFactory
+{
+    /// <summary>
+    /// Finds all source files in the specified project directory.
+    /// </summary>
+    public IEnumerable<SourceFileData> FindSources(string projectDir)
+    {
+        return FindRazorFiles(projectDir);
+    }
+
+    // find and read all razor files in the project directory
+    private IEnumerable<SourceFileData> FindRazorFiles(string projectDir)
+    {
+        var razorFiles = Directory.EnumerateFiles(projectDir, "*.razor", SearchOption.AllDirectories)
+            .Where(file => !file.EndsWith(".g.cs") && !file.EndsWith(".g.i.cs"));
+        foreach (var file in razorFiles)
+        {
+            yield return new SourceFileData
+            {
+                FileType = ParsedFileType.Razor,
+                FilePath = file,
+                FileContent = File.ReadAllText(file)
+            };
+        }
+    }
+}

--- a/src/BlazorPathHelper.Migration/Factory/SourceFileDataFactory.cs
+++ b/src/BlazorPathHelper.Migration/Factory/SourceFileDataFactory.cs
@@ -9,6 +9,16 @@ internal class SourceFileDataFactory
     /// </summary>
     public IEnumerable<SourceFileData> FindSources(string projectDir)
     {
+        if (string.IsNullOrWhiteSpace(projectDir))
+        {
+            throw new ArgumentException("Project directory cannot be null or empty", nameof(projectDir));
+        }
+        
+        if (!Directory.Exists(projectDir))
+        {
+            throw new DirectoryNotFoundException($"Project directory not found: {projectDir}");
+        }
+        
         return FindRazorFiles(projectDir);
     }
 

--- a/src/BlazorPathHelper.Migration/Factory/WebPathItemFactory.cs
+++ b/src/BlazorPathHelper.Migration/Factory/WebPathItemFactory.cs
@@ -1,0 +1,80 @@
+﻿using BlazorPathHelper.Migration.Models;
+using System.Text.RegularExpressions;
+
+namespace BlazorPathHelper.Migration.Factory;
+
+internal partial class WebPathItemFactory
+{
+    /// <summary>
+    /// Generates a WebPathItemStructure from the given source file data.
+    /// </summary>
+    public IEnumerable<WebPathItemStructure> GenerateWebPathItem(
+        SourceFileData source,
+        CommandLineParsedArguments args)
+    {
+        return source.FileType switch
+        {
+            ParsedFileType.Razor => GenerateWebPathItemFromRazor(source, args),
+            // ParsedFileType.Csharp => GenerateWebPathItemFromCsharp(source, args),
+            _ => throw new NotImplementedException($"File type {source.FileType} is not supported.")
+        };
+    }
+
+    /// <summary>
+    /// Generates a WebPathItemStructure from Razor file data.
+    /// </summary>
+    private IEnumerable<WebPathItemStructure> GenerateWebPathItemFromRazor(
+        SourceFileData source,
+        CommandLineParsedArguments args)
+    {
+        // className be equal to the file name
+        // e.g. Sample.razor -> Sample
+        var className = Path.GetFileNameWithoutExtension(source.FilePath);
+        // fullname be equal to the namespace + className
+        // and namespace be equal to the relative path of the file
+        // e.g. /foo/bar/Sample.razor -> foo.bar.Sample
+        var relativePath = Path.GetRelativePath(args.ProjectPath, source.FilePath);
+        var namespaceName = ConvertRelativePathToNamespace(relativePath);
+        var fullClassName = !string.IsNullOrEmpty(namespaceName)
+            ? $"{namespaceName}.{className}"
+            : className;
+        // @page "/test" -> test
+        var extractPageAttributeRegex = RazorPageAttrRegex();
+        var pageAttrMatch = extractPageAttributeRegex.Match(source.FileContent);
+        var pageString = pageAttrMatch.Groups[1].Value;
+        if(string.IsNullOrEmpty(pageString))
+        {
+            yield break;
+        }
+
+        var rst = new WebPathItemStructure {
+            Source = source,
+            Path = pageString,
+            VariableName = className,
+            ComponentFullName = fullClassName,
+        };
+        yield return rst;
+    }
+
+    // Convert the relative path to a namespace by replacing directory separators with dots
+    private static string ConvertRelativePathToNamespace(string relPath)
+    {
+        // for example:
+        // /foo/bar/Sample.razor -> foo.bar.Sample
+        // /foo/bar bar/Sample.razor -> foo.bar_bar.Sample
+        // /foo/bar$$bar/Sample.razor -> foo.bar__bar.Sample
+        var simplePathToNamespace = Path.GetDirectoryName(relPath)
+            ?.Replace(Path.DirectorySeparatorChar, '.')
+            .Replace(Path.AltDirectorySeparatorChar, '.');
+        // and replace special characters with "_"
+        var namespaceName = SpecialCharacterRegex().Replace(simplePathToNamespace ?? "", "_");
+        return namespaceName;
+    }
+
+    // https://regex101.com/r/vVBxis/1
+    [GeneratedRegex(@"@page\s+""(.*?)""", RegexOptions.IgnoreCase, "ja-JP")]
+    private static partial Regex RazorPageAttrRegex();
+
+    [GeneratedRegex(@"^[ -/:-@[-´{-~]*$")]
+    private static partial Regex SpecialCharacterRegex();
+}

--- a/src/BlazorPathHelper.Migration/Helpers/GitStatusHelper.cs
+++ b/src/BlazorPathHelper.Migration/Helpers/GitStatusHelper.cs
@@ -1,0 +1,52 @@
+﻿using Microsoft.Extensions.Logging;
+using ZLogger;
+
+namespace BlazorPathHelper.Migration.Helpers;
+
+internal class CheckGitStatusHelper(
+    ILogger<CheckGitStatusHelper> logger
+)
+{
+    /// <summary>
+    /// Checks if the current git status is clean (no uncommitted changes).
+    /// </summary>
+    public bool IsGitStatusClean(string targetDir)
+    {
+        try
+        {
+            if (!RunGitCommand(targetDir, "rev-parse --is-inside-work-tree").Contains("true"))
+            {
+                logger.ZLogWarning($"current directory is not a git repository. recommend to use git repository to rollback changes.");
+                return false;
+            }
+            var gitStatus = RunGitCommand(targetDir, "status --porcelain");
+            var isClean = string.IsNullOrWhiteSpace(gitStatus);
+            if (!isClean)
+            {
+                logger.ZLogWarning($"Git status is not clean. Please commit or stash your changes.");
+            }
+            return isClean;
+        }
+        catch (Exception)
+        {
+            logger.ZLogError($"Error checking git status.");
+            return false;
+        }
+    }
+
+    private string RunGitCommand(string pwd, string command)
+    {
+        var processStartInfo = new System.Diagnostics.ProcessStartInfo
+        {
+            FileName = "git",
+            Arguments = command,
+            RedirectStandardOutput = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = pwd,
+        };
+        using var process = System.Diagnostics.Process.Start(processStartInfo);
+        using var reader = process?.StandardOutput;
+        return reader?.ReadToEnd() ?? string.Empty;
+    }
+}

--- a/src/BlazorPathHelper.Migration/Helpers/PackageInstallHelper.cs
+++ b/src/BlazorPathHelper.Migration/Helpers/PackageInstallHelper.cs
@@ -1,0 +1,58 @@
+﻿using Microsoft.Extensions.Logging;
+using System.Diagnostics;
+using ZLogger;
+namespace BlazorPathHelper.Migration.Helpers;
+
+internal class PackageInstallHelper(
+    ILogger<PackageInstallHelper> logger
+)
+{
+    private const string PackageName = "BlazorPathHelper";
+
+    /// <summary>
+    /// Installs the BlazorPathHelper package to the specified project directory.
+    /// </summary>
+    public async Task<bool> InstallBlazorPathHelperToProject(string projectDir)
+    {
+        var projectFile = Directory.EnumerateFiles(projectDir, "*.csproj", SearchOption.TopDirectoryOnly)
+            .FirstOrDefault();
+        if (projectFile == null)
+        {
+            throw new FileNotFoundException("Project file not found", projectDir);
+        }
+        var projectFullPath = Path.GetFullPath(projectFile);
+        var projectDirectory = Path.GetDirectoryName(projectFullPath);
+        var projectName = Path.GetFileNameWithoutExtension(projectFile);
+
+        logger.ZLogInformation($"Installing {PackageName} to {projectName} ...");
+
+        var processStartInfo = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = $"add package {PackageName}",
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+            WorkingDirectory = projectDirectory,
+        };
+
+        using var process = Process.Start(processStartInfo);
+        if (process == null)
+        {
+            logger.ZLogError($"Failed to start process to install.");
+            return false;
+        }
+
+        await process.WaitForExitAsync();
+
+        if (process?.ExitCode == 0)
+        {
+            logger.ZLogInformation($"Successfully installed!");
+            return true;
+        }
+        else
+        {
+            logger.ZLogError($"Failed to install. try manually run `dotnet add package {PackageName}`.");
+            return false;
+        }
+    }
+}

--- a/src/BlazorPathHelper.Migration/Helpers/ProjectSelectorHelper.cs
+++ b/src/BlazorPathHelper.Migration/Helpers/ProjectSelectorHelper.cs
@@ -1,0 +1,104 @@
+﻿using Microsoft.Extensions.Logging;
+using Sharprompt;
+using ZLogger;
+
+namespace BlazorPathHelper.Migration.Helpers;
+
+internal class ProjectSelectorHelper(
+    ILogger<ProjectSelectorHelper> logger
+)
+{
+    /// <summary>
+    /// Convert project file paths to directory paths.
+    /// </summary>
+    public string[] ConvertProjectFileToDirectory(string[]? projects)
+    {
+        if (projects == null || projects.Length == 0)
+        {
+            return [];
+        }
+        var directories = new List<string>();
+        foreach (var project in projects)
+        {
+            if (Directory.Exists(project))
+            {
+                directories.Add(project);
+            }
+            else if (Path.GetExtension(project) == ".csproj")
+            {
+                var directory = Path.GetDirectoryName(project);
+                if (directory != null && !directories.Contains(directory))
+                {
+                    directories.Add(directory);
+                }
+            }
+        }
+        return [.. directories];
+    }
+
+    /// <summary>
+    /// select projects from the specified directory.
+    /// </summary>
+    public string[] SelectProjectsFromCurrentDirs()
+    {
+#if DEBUG
+        // for debugging purposes, set the current directory to the root directory of the project.
+        var currentDirectory = "..\\..\\..\\..\\..\\";
+#else
+        var currentDirectory = Environment.CurrentDirectory;
+#endif
+        logger.ZLogDebug($"Current directory: {currentDirectory}");
+        return SelectProjectsFromSpecifiedDirs(currentDirectory) ?? [];
+    }
+
+    /// <summary>
+    /// select projects from the root directory.
+    /// </summary>
+    /// <returns></returns>
+    /// <exception cref="NotImplementedException"></exception>
+    private string[] SelectProjectsFromSpecifiedDirs(string rootDir)
+    {
+        var csprojDirs = ExtractCsprojDirectories(rootDir);
+        if (csprojDirs == null || csprojDirs.Length == 0)
+        {
+            logger.ZLogError($"No csproj files found in the directory.");
+            return [];
+        }
+        var selects = Prompt.MultiSelect(new MultiSelectOptions<FileLocation>()
+        {
+            Message = "Select csproj files to migrate",
+            PageSize = 10,
+            Items = csprojDirs,
+            Minimum = 1,
+            TextSelector = x => $"{x.FileName} ({x.RelativePath(rootDir)})",
+        });
+        if (selects == null || !selects.Any())
+        {
+            logger.ZLogError($"No csproj files selected.");
+            return [];
+        }
+        return [.. selects.Select(x => x.Directory)];
+    }
+
+    /// <summary>
+    /// find csproj existed directories from the root directory.
+    /// </summary>
+    private static FileLocation[]? ExtractCsprojDirectories(string rootDir)
+    {
+        var csprojFiles = Directory.EnumerateFiles(rootDir, "*.csproj", SearchOption.AllDirectories);
+        if (csprojFiles == null || !csprojFiles.Any())
+        {
+            return null;
+        }
+        return [.. csprojFiles.Select(x => new FileLocation(x))];
+    }
+}
+
+// This class is used to represent a file location.
+internal record FileLocation(string CsProjPath)
+{
+    public string FilePath => Path.GetFullPath(CsProjPath) ?? string.Empty;
+    public string FileName => Path.GetFileName(CsProjPath) ?? string.Empty;
+    public string Directory => Path.GetDirectoryName(CsProjPath) ?? string.Empty;
+    public string RelativePath(string path) => Path.GetRelativePath(path, Directory);
+}

--- a/src/BlazorPathHelper.Migration/MigrationApp.cs
+++ b/src/BlazorPathHelper.Migration/MigrationApp.cs
@@ -1,0 +1,96 @@
+﻿using BlazorPathHelper.Migration.Builder;
+using BlazorPathHelper.Migration.Factory;
+using BlazorPathHelper.Migration.Helpers;
+using BlazorPathHelper.Migration.Models;
+using ConsoleAppFramework;
+using Microsoft.Extensions.Logging;
+using Sharprompt;
+using ZLogger;
+
+/// <summary>
+/// This class contains the commands for the console application.
+/// </summary>
+internal class MigrationApp(
+    ProjectSelectorHelper projectSelectHelper,
+    PackageInstallHelper packageInstallHelper,
+    SourceFileDataFactory sourceFileDataFactory,
+    WebPathItemFactory webPathItemFactory,
+    WebPathsFileExporter webPathsFileBuilder,
+    CheckGitStatusHelper gitStatusHelper,
+    ILogger<MigrationApp> logger
+)
+{
+    /// <summary>
+    /// Analyzes Razor components/pages in the specified project and generates code usable with BlazorPathHelper.
+    /// </summary>
+    /// <param name="projects">-p, The directory containing the .csproj file or the path to the `.csproj` file. If not specified, a selection form will be displayed.</param>
+    /// <param name="replacePageAttrString">-r, Whether to replace the PageAttribute string. If not specified, confirmation will be prompted.</param>
+    /// <param name="outputClassName">-c, The name of the generated class.</param>
+    /// <param name="outputPath">-o, Specifies the output destination for the generated code.</param>
+    /// <param name="forceExport">--force, Whether to overwrite the file if it already exists in the output destination. If not specified, confirmation will be prompted.</param>
+    /// <param name="dryRun">Whether to perform a dry run. If true, the code will not be generated.</param>
+    [Command("")]
+    public async Task<int> Migration(
+        string[]? projects = null,
+        bool? replacePageAttrString = null,
+        string outputClassName = "WebPaths",
+        string outputPath = "./",
+        bool forceExport = false,
+        bool dryRun = false
+    )
+    {
+        // parse command line arguments
+        var convertedProjects = projectSelectHelper.ConvertProjectFileToDirectory(projects);
+        var selectedProjects = convertedProjects.Length > 0
+            ? convertedProjects
+            : projectSelectHelper.SelectProjectsFromCurrentDirs();
+        var isReplacePageAttributeString = replacePageAttrString ??
+            Prompt.Confirm("Replace @page attribute string to generated variable ?", true);
+        //var isQueryBuilderSupport = queryBuilderSupport ??
+        //    Prompt.Confirm("Generate [Query] attributes from [SupportQueryBuilder] values ?", false);
+        foreach (var project in selectedProjects)
+        {
+            var args = new CommandLineParsedArguments()
+            {
+                ProjectPath = project,
+                OutputClassName = outputClassName,
+                OutputDir = outputPath,
+                ForceExport = forceExport,
+                DisableInteractiveMode = false,
+                IsDryRun = dryRun,
+                IsReplacePageAttributeString = isReplacePageAttributeString,
+                QueryBuilderSupport = false, // isQueryBuilderSupport
+            };
+
+            if(!gitStatusHelper.IsGitStatusClean(project) &&
+                !Prompt.Confirm($"Git status is not clean. Do you want to continue ?", false))
+            {
+                logger.ZLogInformation($"Aborting migration.");
+                return 1; // error
+            }
+
+            // try install
+            await packageInstallHelper.InstallBlazorPathHelperToProject(project);
+            // parse source files
+            var sources = sourceFileDataFactory.FindSources(args.ProjectPath);
+            var webPathItems = sources
+                .SelectMany(source => webPathItemFactory.GenerateWebPathItem(source, args))
+                .OrderBy(w => w.Path);
+            // generate code
+            var webPathsFile = webPathsFileBuilder.ExtendFileContent(webPathItems, args);
+            // export code
+            webPathsFileBuilder.ExportGeneratedWebPathsFile(webPathsFile, args);
+            // replace @page attribute string
+            webPathsFileBuilder.ReplaceRazorPageAttributeToVariable(webPathItems, args);
+        }
+        return 0; // success
+    }
+
+    /// <summary>
+    /// print version information.
+    /// </summary>
+    public void Version()
+    {
+        Console.WriteLine(ThisAssembly.AssemblyInformationalVersion);
+    }
+}

--- a/src/BlazorPathHelper.Migration/Models/CommandLineParsedArguments.cs
+++ b/src/BlazorPathHelper.Migration/Models/CommandLineParsedArguments.cs
@@ -1,0 +1,68 @@
+﻿namespace BlazorPathHelper.Migration.Models;
+
+
+/// <summary>
+/// This record stores the parsed results of the command-line arguments.
+/// </summary>
+internal record CommandLineParsedArguments
+{
+    /// <summary>
+    /// Paths to the target projects.
+    /// </summary>
+    public required string ProjectPath { get; init; }
+
+    /// <summary>
+    /// Whether to replace the @page attribute string with a generated variable.
+    /// </summary>
+    public required bool IsReplacePageAttributeString { get; init; }
+
+    /// <summary>
+    /// Whether to generate [Query] attributes from [SupportQueryBuilder] values.
+    /// </summary>
+    public required bool QueryBuilderSupport { get; init; }
+
+    /// <summary>
+    /// The name of the generated class.
+    /// </summary>
+    public required string OutputClassName { get; init; } 
+
+    /// <summary>
+    /// The output directory for the generated code.
+    /// </summary>
+    public required string OutputDir { get; init; }
+
+    /// <summary>
+    /// Whether to overwrite existing files in the output path.
+    /// </summary>
+    public required bool ForceExport { get; init; }
+
+    /// <summary>
+    /// Whether to disable interactive mode.
+    /// </summary>
+    public required bool DisableInteractiveMode { get; init; }
+
+    /// <summary>
+    /// Whether to perform a dry run (no code generation).
+    /// </summary>
+    public required bool IsDryRun { get; init; } = false;
+
+    /// <summary>
+    /// The full path to the output file.
+    /// </summary>
+    public string OutputFileFullPath
+        => Path.Combine(ProjectPath, OutputDir, $"{OutputClassName}.cs");
+
+    /// <summary>
+    /// Returns a string representation of the command-line arguments.
+    /// </summary>
+    public override string ToString()
+    {
+        return $"ProjectPath: {ProjectPath}, " +
+               $"IsReplacePageAttributeString: {IsReplacePageAttributeString}, " +
+               $"QueryBuilderSupport: {QueryBuilderSupport}, " +
+               $"OutputPath: {OutputDir}, " +
+               $"ForceExport: {ForceExport}, " +
+               $"DisableInteractiveMode: {DisableInteractiveMode}, " +
+               $"IsDryRun: {IsDryRun}";
+    }
+}

--- a/src/BlazorPathHelper.Migration/Models/SourceFileData.cs
+++ b/src/BlazorPathHelper.Migration/Models/SourceFileData.cs
@@ -1,0 +1,19 @@
+﻿
+namespace BlazorPathHelper.Migration.Models;
+
+/// <summary>
+/// This class stores the parsed data of a source file.
+/// </summary>
+internal class SourceFileData
+{
+    public required ParsedFileType FileType { get; init; }
+    public required string FilePath { get; init;  }
+    public required string FileContent { get; init; }
+}
+
+internal enum ParsedFileType
+{
+    Razor,
+    Csharp,
+    // CsHtml
+}

--- a/src/BlazorPathHelper.Migration/Models/WebPathItemStructure.cs
+++ b/src/BlazorPathHelper.Migration/Models/WebPathItemStructure.cs
@@ -1,0 +1,56 @@
+﻿using Microsoft.CodeAnalysis.CSharp;
+
+namespace BlazorPathHelper.Migration.Models;
+
+internal class WebPathItemStructure
+{
+    public required SourceFileData Source { get; init; }
+    public required string Path { get; init; }
+    public required string VariableName { get; init; }
+    public required string ComponentFullName { get; init; }
+
+    public SyntaxKind Accessibility { get; init; } = SyntaxKind.PublicKeyword;
+    public List<WebPathQueryStructure> QueryParameters { get; init; } = [];
+
+    public string ComponentName => ComponentFullName.Split('.').Last();
+    public bool HasQueryParameters => QueryParameters.Count > 0;
+
+    /// <summary>
+    /// Generates a variable name for the web path item, ensuring no conflicts with existing variable names.
+    /// </summary>
+    public string NoConflictVariableName(
+        IEnumerable<WebPathItemStructure> webPaths)
+    {
+        // find same variablename from webpaths
+        var sameVariableName = webPaths
+            .Where(w => w.ComponentFullName != ComponentFullName)
+            .Where(w => w.VariableName == VariableName);
+        // if no same variablename, return the original
+        if (!sameVariableName.Any())
+        {
+            return VariableName;
+        }
+        // if same variable name exists, use fullname
+        return ComponentFullName.Replace(".", "_");
+    }
+
+    /// <summary>
+    /// Generates a string representation of the web path item structure.
+    /// </summary>
+    public override string ToString()
+    {
+        return $"Path: {Path}, " +
+               $"VariableName: {VariableName}, " +
+               $"ComponentFullName: {ComponentFullName}, " +
+               $"Accessibility: {Accessibility}, " +
+               $"QueryParameters: [{string.Join(", ", QueryParameters.Select(q => q.Name))}]";
+    }
+
+}
+
+internal class WebPathQueryStructure
+{
+    public required string Name { get; init; }
+    public required string Type { get; init; }
+    public string? DefaultValue { get; init; }
+}

--- a/src/BlazorPathHelper.Migration/Program.cs
+++ b/src/BlazorPathHelper.Migration/Program.cs
@@ -1,0 +1,31 @@
+﻿using BlazorPathHelper.Migration.Builder;
+using BlazorPathHelper.Migration.Factory;
+using BlazorPathHelper.Migration.Helpers;
+using ConsoleAppFramework;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using ZLogger;
+
+var app = ConsoleApp.Create()
+    .ConfigureLogging(config => {
+        config.ClearProviders();
+        config.SetMinimumLevel(LogLevel.Debug);
+        config.AddZLoggerConsole(options => {
+            options.IncludeScopes = true;
+            options.UsePlainTextFormatter(formatter => {
+                formatter.SetPrefixFormatter($"{0:local-timeonly} [{1:short}] ",
+                    (in MessageTemplate template, in LogInfo info) => template.Format(info.Timestamp, info.LogLevel));
+            });
+        });
+    })
+    .ConfigureServices(services => {
+        services.AddSingleton<ProjectSelectorHelper>();
+        services.AddSingleton<PackageInstallHelper>();
+        services.AddSingleton<CheckGitStatusHelper>();
+        services.AddSingleton<WebPathItemFactory>();
+        services.AddSingleton<SourceFileDataFactory>();
+        services.AddSingleton<WebPathsFileExporter>();
+        services.AddLogging();
+    });
+app.Add<MigrationApp>();
+app.Run(args);

--- a/src/BlazorPathHelper.Migration/packages.lock.json
+++ b/src/BlazorPathHelper.Migration/packages.lock.json
@@ -1,0 +1,154 @@
+{
+  "version": 1,
+  "dependencies": {
+    "net8.0": {
+      "ConsoleAppFramework": {
+        "type": "Direct",
+        "requested": "[5.*, )",
+        "resolved": "5.4.1",
+        "contentHash": "2QlC0lYN8Qfu9Hwe+6tp/ZqG8gFN4jTHgaOQwpszLYa6Mtw2rXcsacaSBqS+Gt6HeO8oSSJJdKze6AnYuHSN6A=="
+      },
+      "Microsoft.CodeAnalysis.Analyzers": {
+        "type": "Direct",
+        "requested": "[3.11.0, )",
+        "resolved": "3.11.0",
+        "contentHash": "v/EW3UE8/lbEYHoC2Qq7AR/DnmvpgdtAMndfQNmpuIMx/Mto8L5JnuCfdBYtgvalQOtfNCnxFejxuRrryvUTsg=="
+      },
+      "Microsoft.CodeAnalysis.CSharp": {
+        "type": "Direct",
+        "requested": "[4.13.0, )",
+        "resolved": "4.13.0",
+        "contentHash": "BsH7Vijbj9IL7Fj4k/ysZSVyLGFqr75wmdFGwCKWJvSjnA1xwPaQ3hkB2BQdHOt5CpEYA6Q0I6Oo5sDTDHqHsg==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "[4.13.0]",
+          "System.Collections.Immutable": "8.0.0",
+          "System.Reflection.Metadata": "8.0.0"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Direct",
+        "requested": "[8.*, )",
+        "resolved": "8.0.1",
+        "contentHash": "BmANAnR5Xd4Oqw7yQ75xOAYODybZQRzdeNucg7kS5wWKd2PNnMdYtJ2Vciy0QLylRmv42DGl5+AFL9izA6F1Rw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2"
+        }
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Direct",
+        "requested": "[8.*, )",
+        "resolved": "8.0.1",
+        "contentHash": "4x+pzsQEbqxhNf1QYRr5TDkLP9UsLT3A6MdRKDDEgrW7h1ljiEPgTNhKYUhNCCAaVpQECVQ+onA91PTPnIp6Lw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "8.0.1",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.2",
+          "Microsoft.Extensions.Options": "8.0.2"
+        }
+      },
+      "Nerdbank.GitVersioning": {
+        "type": "Direct",
+        "requested": "[3.*, )",
+        "resolved": "3.7.115",
+        "contentHash": "EpXamaAdRfG/BMxGgvZlTM0npRnkmXUjAj8OdNKd17t4oN+2nvjdv/KnFmzOOMDqvlwB49UCwtOHJrAQTfUBtQ=="
+      },
+      "PolySharp": {
+        "type": "Direct",
+        "requested": "[1.*, )",
+        "resolved": "1.15.0",
+        "contentHash": "FbU0El+EEjdpuIX4iDbeS7ki1uzpJPx8vbqOzEtqnl1GZeAGJfq+jCbxeJL2y0EPnUNk8dRnnqR2xnYXg9Tf+g=="
+      },
+      "Sharprompt": {
+        "type": "Direct",
+        "requested": "[2.*, )",
+        "resolved": "2.4.5",
+        "contentHash": "hRYlerWsQGbm+okcxGrHzlm0n7wwVR2si1faSqt4IaO8iZcOKwW/MrBZgLiGRd2TVzFYGv22OuBoR2AatSlJbQ==",
+        "dependencies": {
+          "System.ComponentModel.Annotations": "5.0.0"
+        }
+      },
+      "ZLogger": {
+        "type": "Direct",
+        "requested": "[2.*, )",
+        "resolved": "2.5.10",
+        "contentHash": "KjQaJ1M3b7cuouXwxhX1CEyCqQ1mOlFslGe5lSELmDYIo5kemzi2Y23jeESqtXrNw+iLLN2+89qpm9Il/cG0bg==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging": "8.0.0",
+          "System.IO.Hashing": "8.0.0",
+          "System.Threading.Channels": "8.0.0",
+          "Utf8StringInterpolation": "1.3.1"
+        }
+      },
+      "Microsoft.CodeAnalysis.Common": {
+        "type": "Transitive",
+        "resolved": "4.13.0",
+        "contentHash": "T8nRl4mAUY4mhdYM4U2ra2vP2EL+ol8Yqwo0gwC/V55vmlXq9NxdIkZJynTpTL1uX/jHijJ90AeOEx4lf7OwzQ==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "System.Collections.Immutable": "8.0.0",
+          "System.Reflection.Metadata": "8.0.0"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "8.0.2",
+        "contentHash": "3iE7UF7MQkCv1cxzCahz+Y/guQbTqieyxyaWKhrRO91itI9cOKO76OHeQDahqG4MmW5umr3CcCvGmK92lWNlbg=="
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "Transitive",
+        "resolved": "8.0.2",
+        "contentHash": "nroMDjS7hNBPtkZqVBbSiQaQjWRDxITI8Y7XnDs97rqG3EbzVTNLZQf7bIeUJcaHOV8bca47s1Uxq94+2oGdxA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "Transitive",
+        "resolved": "8.0.2",
+        "contentHash": "dWGKvhFybsaZpGmzkGCbNNwBD1rVlWzrZKANLW/CcbFJpCEceMCGzT7zZwHOGBCbwM0SzBuceMj5HN1LKV1QqA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.0",
+          "Microsoft.Extensions.Primitives": "8.0.0"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "bXJEZrW9ny8vjMF1JV253WeLhpEVzFo1lyaZu1vQ4ZxWUlVvknZ/+ftFgVheLubb4eZPSwwxBeqS1JkCOjxd8g=="
+      },
+      "System.Collections.Immutable": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "AurL6Y5BA1WotzlEvVaIDpqzpIPvYnnldxru8oXJU2yFxFUy3+pNXjXd1ymO+RA0rq0+590Q8gaz2l3Sr7fmqg=="
+      },
+      "System.ComponentModel.Annotations": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "dMkqfy2el8A8/I76n2Hi1oBFEbG1SfxD2l5nhwXV3XjlnOmwxJlQbYpJH4W51odnU9sARCSAgv7S3CyAFMkpYg=="
+      },
+      "System.IO.Hashing": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "ne1843evDugl0md7Fjzy6QjJrzsjh46ZKbhf8GwBXb5f/gw97J4bxMs0NQKifDuThh/f0bZ0e62NPl1jzTuRqA=="
+      },
+      "System.Reflection.Metadata": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "ptvgrFh7PvWI8bcVqG5rsA/weWM09EnthFHR5SCnS6IN+P4mj6rE1lBDC4U8HL9/57htKAqy4KQ3bBj84cfYyQ==",
+        "dependencies": {
+          "System.Collections.Immutable": "8.0.0"
+        }
+      },
+      "System.Threading.Channels": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "CMaFr7v+57RW7uZfZkPExsPB6ljwzhjACWW1gfU35Y56rk72B/Wu+sTqxVmGSk4SFUlPc3cjeKND0zktziyjBA=="
+      },
+      "Utf8StringInterpolation": {
+        "type": "Transitive",
+        "resolved": "1.3.1",
+        "contentHash": "VIo1LtpoFvp5LlCDkTiQsKrjX+GMA7N37OEJoqHMhCOdIeNoi8uFocnwi8h3TklSySB3U4Y1+gThB00fJTnfGA=="
+      }
+    }
+  }
+}

--- a/tests/BlazorPathHelper.Tests/BlazorPathHelper.Tests.csproj
+++ b/tests/BlazorPathHelper.Tests/BlazorPathHelper.Tests.csproj
@@ -7,6 +7,17 @@
         <RootNamespace>BlazorPathHelper.Tests</RootNamespace>
     </PropertyGroup>
 
+	<ItemGroup>
+		<ProjectReference Include="..\..\src\BlazorPathHelper.Core\BlazorPathHelper.Core.csproj">
+			<OutputItemType>Analyzer</OutputItemType>
+			<ReferenceOutputAssembly>true</ReferenceOutputAssembly>
+		</ProjectReference>
+		<ProjectReference Include="..\..\src\BlazorPathHelper.Generator\BlazorPathHelper.Generator.csproj">
+			<OutputItemType>Analyzer</OutputItemType>
+			<ReferenceOutputAssembly>true</ReferenceOutputAssembly>
+		</ProjectReference>
+	</ItemGroup>
+
     <ItemGroup>
       <EmbeddedResource Update="Resources\Localize.resx">
         <Generator>ResXFileCodeGenerator</Generator>

--- a/tests/BlazorPathHelper.Tests/BlazorPathHelper.Tests.csproj
+++ b/tests/BlazorPathHelper.Tests/BlazorPathHelper.Tests.csproj
@@ -8,28 +8,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AwesomeAssertions" Version="7.*" />
-        <PackageReference Include="Microsoft.AspNetCore.Components" Version="8.0.11" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
-        <PackageReference Include="xunit" Version="2.*" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.*">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-    </ItemGroup>
-
-    <ItemGroup>
-        <ProjectReference Include="..\..\src\BlazorPathHelper.Core\BlazorPathHelper.Core.csproj">
-            <OutputItemType>Analyzer</OutputItemType>
-            <ReferenceOutputAssembly>true</ReferenceOutputAssembly>
-        </ProjectReference>
-        <ProjectReference Include="..\..\src\BlazorPathHelper.Generator\BlazorPathHelper.Generator.csproj">
-            <OutputItemType>Analyzer</OutputItemType>
-            <ReferenceOutputAssembly>true</ReferenceOutputAssembly>
-        </ProjectReference>
-    </ItemGroup>
-
-    <ItemGroup>
       <EmbeddedResource Update="Resources\Localize.resx">
         <Generator>ResXFileCodeGenerator</Generator>
         <LastGenOutput>Localize.Designer.cs</LastGenOutput>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -4,4 +4,16 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AwesomeAssertions" Version="7.*" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="8.0.11" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
+    <PackageReference Include="xunit" Version="2.*" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.*">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Introduce a migration tool for BlazorPathHelper to streamline project setup and enhance documentation for easier usage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Launched an automated migration tool for converting Razor components with enhanced options like attribute replacement, project selection, and dry-run mode.
  
- **Documentation**
  - Updated installation and usage guides (available in English, Japanese, and Chinese), providing streamlined setup instructions and alternative automatic installation options.
  
- **Chores**
  - Adjusted version control to ignore the sandbox directory for cleaner commit management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->